### PR TITLE
[BREAKING CHANGE] Refactor API to take in a username and output an iterator of `GameData` instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ documentation = "https://docs.rs/hikaru/"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
-serde = {version = "1.0", features=["derive"]}
-serde_json = {version = "1.0"}
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ readme = "README.md"
 documentation = "https://docs.rs/hikaru/"
 
 [dependencies]
-reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+reqwest = { version = "~0.11", features = ["blocking", "rustls-tls"] }
+serde = { version = "~1.0", features = ["derive"] }
+serde_json = { version = "~1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hikaru"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Eli Ben-Porat <github@ben-porat.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Readme.md
+++ b/Readme.md
@@ -1,15 +1,10 @@
 # Hikaru
-
 Hikaru (the library), is a simple wrapper around the chess.com API that makes it easy to download game data.
 
 ## Usage
-
 ```rust
 use hikaru::GameData;
 
-let user_names = vec!["hikaru","GMHikaruOnTwitch"];
-let games = GameData::download(user_names);
- 
-// Check out Hikaru's first game on Chess.com:
-dbg!(&games[0]);
+// Check out Hikaru's first game on Chess.com
+dbg!(Gamedata::download("hikaru").next())
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 # Hikaru
-Hikaru (the library), is a simple wrapper around the chess.com API that makes it easy to download game data.
+_Hikaru_ (the crate) is a simple wrapper around the [Chess.com API](https://www.chess.com/news/view/published-data-api) that makes it easy to fetch the game data of a single player.
 
 ## Usage
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,14 @@
 //! so this can be fed into the engine for a variety of analyses.
 
 use reqwest::blocking::get;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct GameUrls {
     archives: Vec<String>,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TimeClass {
     Bullet,
@@ -34,7 +34,7 @@ pub enum TimeClass {
     Daily,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Rules {
     Chess,
@@ -67,7 +67,7 @@ struct Game {
     black: Player,
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum GameResult {
     Win,
@@ -88,7 +88,7 @@ pub enum GameResult {
     BugHousePartnerWin,
 }
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, Deserialize)]
 pub enum GameResultWinLose {
     Win,
     Loss,
@@ -106,7 +106,7 @@ impl From<GameResult> for GameResultWinLose {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 struct Player {
     username: String,
     rating: u32,
@@ -177,7 +177,7 @@ impl From<&str> for PGN {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize)]
 pub struct GameData {
     pub game_url: String,
     pub time_control: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ struct GameUrls {
     archives: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TimeClass {
     Bullet,
@@ -34,7 +34,7 @@ pub enum TimeClass {
     Daily,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Rules {
     Chess,
@@ -180,7 +180,7 @@ pub enum GameResult {
     BugHousePartnerWin,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub enum GameResultWinLose {
     Win,
     Loss,
@@ -213,7 +213,7 @@ struct Games {
 }
 
 #[allow(non_snake_case)]
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Debug)]
 struct PGN {
     ECO: String,
     ECO_url: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,14 @@
 //! so this can be fed into the engine for a variety of analyses.
 
 use reqwest::blocking::get;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct GameUrls {
     archives: Vec<String>,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TimeClass {
     Bullet,
@@ -34,7 +34,7 @@ pub enum TimeClass {
     Daily,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Rules {
     Chess,
@@ -47,7 +47,7 @@ pub enum Rules {
     OddsChess,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Game {
     #[serde(rename = "url")]
     game_url: String,
@@ -67,7 +67,7 @@ struct Game {
     black: Player,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum GameResult {
     Win,
@@ -88,7 +88,7 @@ pub enum GameResult {
     BugHousePartnerWin,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub enum GameResultWinLose {
     Win,
     Loss,
@@ -106,7 +106,7 @@ impl From<GameResult> for GameResultWinLose {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Player {
     username: String,
     rating: u32,
@@ -115,13 +115,13 @@ struct Player {
     id: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Games {
     games: Vec<Game>,
 }
 
 #[allow(non_snake_case)]
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, Serialize)]
 struct PGN {
     ECO: String,
     ECO_url: String,
@@ -177,7 +177,7 @@ impl From<&str> for PGN {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GameData {
     pub game_url: String,
     pub time_control: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ struct Games {
 }
 
 #[allow(non_snake_case)]
-#[derive(Debug)]
+#[derive(Default, Debug)]
 struct PGN {
     ECO: String,
     ECO_url: String,
@@ -255,6 +255,7 @@ impl From<Option<String>> for PGN {
                         .into();
                 }
             }
+
             Self {
                 ECO: eco,
                 ECO_url: eco_url,
@@ -264,14 +265,7 @@ impl From<Option<String>> for PGN {
                 start_date: "".to_string(),
             }
         } else {
-            Self {
-                ECO: "".to_string(),
-                ECO_url: "".to_string(),
-                UTC_date: "".to_string(),
-                UTC_time: "".to_string(),
-                start_time: "".to_string(),
-                start_date: "".to_string(),
-            }
+            Default::default()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,98 +67,6 @@ struct Game {
     black: Player,
 }
 
-#[derive(Debug, Serialize)]
-pub struct GameData {
-    pub game_url: String,
-    pub time_control: String,
-    pub start_time: Option<u32>,
-    pub end_time: u32,
-    pub rated: bool,
-    pub fen: String,
-    pub time_class: TimeClass,
-    pub rules: Rules,
-    pub eco_game: Option<String>,
-    pub tournament: Option<String>,
-    #[serde(rename = "match")]
-    pub team_match: Option<String>,
-    pub white_rating: u32,
-    pub white_username: String,
-    pub black_rating: u32,
-    pub black_username: String,
-    pub eco_pgn: String,
-    pub eco_url: String,
-    pub result: GameResult,
-    pub result_win_lose: GameResultWinLose,
-    pub rating: u32,
-    pub date: String,
-    pub colour: String,
-    pub win: f32,
-    pub player_username: String,
-}
-
-impl GameData {
-    pub fn download<'a>(user: &'a str) -> impl Iterator<Item = GameData> + 'a {
-        get_game_month_urls(user)
-            .into_iter()
-            .flat_map(|url| get_games(&url))
-            .map(move |game| (game, user).into())
-    }
-}
-
-impl From<(Game, &str)> for GameData {
-    fn from((game, user): (Game, &str)) -> Self {
-        let pgn: PGN = game.pgn.as_deref().map(PGN::from).unwrap_or_default();
-
-        let is_white = user == game.white.username;
-        let result = if is_white {
-            game.white.result
-        } else {
-            game.black.result
-        };
-        let result_win_lose = result.into();
-
-        let rating = if is_white {
-            game.white.rating
-        } else {
-            game.black.rating
-        };
-        let colour = if is_white { "White" } else { "Black" };
-
-        let win = match result_win_lose {
-            GameResultWinLose::Win => 1.0,
-            GameResultWinLose::Draw => 0.5,
-            GameResultWinLose::Loss => 0.0,
-        };
-
-        Self {
-            game_url: game.game_url,
-            time_control: game.time_control,
-            start_time: game.start_time,
-            end_time: game.end_time,
-            rated: game.rated,
-            fen: game.fen,
-            time_class: game.time_class,
-            rules: game.rules,
-            eco_game: game.eco,
-            tournament: game.tournament,
-            team_match: game.team_match,
-            result,
-            result_win_lose,
-            white_rating: game.white.rating,
-            white_username: game.white.username,
-            black_rating: game.black.rating,
-            black_username: game.black.username,
-            eco_pgn: pgn.ECO,
-            eco_url: pgn.ECO_url,
-            rating,
-            colour: colour.into(),
-            win,
-            player_username: user.into(),
-            date: pgn.UTC_date,
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum GameResult {
@@ -280,6 +188,98 @@ fn get_game_month_urls(user: &str) -> Vec<String> {
     serde_json::from_str::<GameUrls>(&text)
         .expect("Serde error!")
         .archives
+}
+
+#[derive(Debug, Serialize)]
+pub struct GameData {
+    pub game_url: String,
+    pub time_control: String,
+    pub start_time: Option<u32>,
+    pub end_time: u32,
+    pub rated: bool,
+    pub fen: String,
+    pub time_class: TimeClass,
+    pub rules: Rules,
+    pub eco_game: Option<String>,
+    pub tournament: Option<String>,
+    #[serde(rename = "match")]
+    pub team_match: Option<String>,
+    pub white_rating: u32,
+    pub white_username: String,
+    pub black_rating: u32,
+    pub black_username: String,
+    pub eco_pgn: String,
+    pub eco_url: String,
+    pub result: GameResult,
+    pub result_win_lose: GameResultWinLose,
+    pub rating: u32,
+    pub date: String,
+    pub colour: String,
+    pub win: f32,
+    pub player_username: String,
+}
+
+impl GameData {
+    pub fn download<'a>(user: &'a str) -> impl Iterator<Item = GameData> + 'a {
+        get_game_month_urls(user)
+            .into_iter()
+            .flat_map(|url| get_games(&url))
+            .map(move |game| (game, user).into())
+    }
+}
+
+impl From<(Game, &str)> for GameData {
+    fn from((game, user): (Game, &str)) -> Self {
+        let pgn: PGN = game.pgn.as_deref().map(PGN::from).unwrap_or_default();
+
+        let is_white = user == game.white.username;
+        let result = if is_white {
+            game.white.result
+        } else {
+            game.black.result
+        };
+        let result_win_lose = result.into();
+
+        let rating = if is_white {
+            game.white.rating
+        } else {
+            game.black.rating
+        };
+        let colour = if is_white { "White" } else { "Black" };
+
+        let win = match result_win_lose {
+            GameResultWinLose::Win => 1.0,
+            GameResultWinLose::Draw => 0.5,
+            GameResultWinLose::Loss => 0.0,
+        };
+
+        Self {
+            game_url: game.game_url,
+            time_control: game.time_control,
+            start_time: game.start_time,
+            end_time: game.end_time,
+            rated: game.rated,
+            fen: game.fen,
+            time_class: game.time_class,
+            rules: game.rules,
+            eco_game: game.eco,
+            tournament: game.tournament,
+            team_match: game.team_match,
+            result,
+            result_win_lose,
+            white_rating: game.white.rating,
+            white_username: game.white.username,
+            black_rating: game.black.rating,
+            black_username: game.black.username,
+            eco_pgn: pgn.ECO,
+            eco_url: pgn.ECO_url,
+            rating,
+            colour: colour.into(),
+            win,
+            player_username: user.into(),
+            date: pgn.UTC_date,
+        }
+    }
 }
 
 fn get_games(url: &str) -> Vec<Game> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,39 +1,35 @@
 //! # Hikaru
-//! 
-//! Hikaru provides Rust bindings to the Chess.com API, specifically for downloading all of a player's games. It is named after Grand Master Hikaru Nakamura (unless he objects, in which case I'll change the name). 
-//! JSON parsing is done via SereE; reqwest is used to get data from the API.
-//! 
+//! Hikaru provides Rust bindings to the Chess.com API, specifically for downloading all of a player's games.
+//! It is named after Grand Master Hikaru Nakamura (unless he objects, in which case I'll change the name).
+//! JSON parsing is done via `serde`; `reqwest` is used to get data from the API.
+//!
 //! ## How to Use
-//! 
 //! All you have to do is feed Hikaru a list of usernames, and you get back a Vec<[GameData]>
-//! 
+//!
 //! ```rust
 //! use hikaru::GameData;
-//! 
+//!
 //! let user_names = vec!["hikaru","GMHikaruOnTwitch"];
 //! let games = GameData::download(user_names);
-//! 
+//!
 //! // Check out Hikaru's first game on Chess.com:
 //! dbg!(&games[0]);
 //! ```
-//! 
-//! ## Future plans
-//! 
-//! Create a stockfish wrapper so that you can analyze all your games. The game data include all the moves made in those games, so this can be fed into the engine for a variety of analyses.
-//! 
+//!
+//! ## Future Plans
+//! Create a Stockfish wrapper so that you can analyze all your games. The game data include all the moves made in those games,
+//! so this can be fed into the engine for a variety of analyses.
 
 use reqwest::blocking::get;
 use serde::{Deserialize, Serialize};
 
-
 #[derive(Deserialize)]
 struct GameUrls {
-    archives: Vec<String>
+    archives: Vec<String>,
 }
 
-
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum TimeClass {
     Bullet,
     Blitz,
@@ -42,7 +38,7 @@ pub enum TimeClass {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum Rules {
     Chess,
     Chess960,
@@ -51,13 +47,12 @@ pub enum Rules {
     KingOfTheHill,
     Horde,
     BugHouse,
-    OddsChess
+    OddsChess,
 }
-
 
 #[derive(Debug, Deserialize)]
 struct Game {
-    #[serde(rename="url")]
+    #[serde(rename = "url")]
     game_url: String,
     pgn: Option<String>,
     time_control: String,
@@ -69,7 +64,7 @@ struct Game {
     rules: Rules,
     eco: Option<String>,
     tournament: Option<String>,
-    #[serde(rename="match")]
+    #[serde(rename = "match")]
     team_match: Option<String>,
     white: Player,
     black: Player,
@@ -87,7 +82,7 @@ pub struct GameData {
     pub rules: Rules,
     pub eco_game: Option<String>,
     pub tournament: Option<String>,
-    #[serde(rename="match")]
+    #[serde(rename = "match")]
     pub team_match: Option<String>,
     pub white_rating: u32,
     pub white_username: String,
@@ -105,25 +100,31 @@ pub struct GameData {
 }
 
 impl From<(Game, &str)> for GameData {
-    fn from (game_data: (Game, &str)) -> Self {
+    fn from(game_data: (Game, &str)) -> Self {
         let game = game_data.0;
         let user = game_data.1;
         let pgn: PGN = game.pgn.into();
-        
+
         let is_white = user == game.white.username;
 
-        let result = if is_white {game.white.result} else {game.black.result};
+        let result = if is_white {
+            game.white.result
+        } else {
+            game.black.result
+        };
         let result_win_lose = result.into();
-        let rating = if is_white {game.white.rating} else {game.black.rating};
-        let colour = if is_white {"White"} else {"Black"};
+        let rating = if is_white {
+            game.white.rating
+        } else {
+            game.black.rating
+        };
+        let colour = if is_white { "White" } else { "Black" };
 
-        
-        let win = 
-            match result_win_lose {
-                GameResultWinLose::Win => 1.0,
-                GameResultWinLose::Draw => 0.5,
-                GameResultWinLose::Loss => 0.0,
-            };
+        let win = match result_win_lose {
+            GameResultWinLose::Win => 1.0,
+            GameResultWinLose::Draw => 0.5,
+            GameResultWinLose::Loss => 0.0,
+        };
 
         GameData {
             game_url: game.game_url,
@@ -154,11 +155,8 @@ impl From<(Game, &str)> for GameData {
     }
 }
 
-
-
-
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum GameResult {
     Win,
     TimeOut,
@@ -169,7 +167,7 @@ pub enum GameResult {
     Repetition,
     Insufficient,
     Abandoned,
-    #[serde(rename="50move")]
+    #[serde(rename = "50move")]
     FiftyMove,
     TimeVsInsufficient,
     KingOfTheHill,
@@ -186,7 +184,7 @@ pub enum GameResultWinLose {
 }
 
 impl From<GameResult> for GameResultWinLose {
-    fn from( res: GameResult) -> Self {
+    fn from(res: GameResult) -> Self {
         use GameResult::*;
         match res {
             Win | BugHousePartnerWin | KingOfTheHill | ThreeCheck => Self::Win,
@@ -201,13 +199,13 @@ struct Player {
     username: String,
     rating: u32,
     result: GameResult,
-    #[serde(rename="@id")]
+    #[serde(rename = "@id")]
     id: String,
 }
 
 #[derive(Debug, Deserialize)]
 struct Games {
-    games: Vec<Game>
+    games: Vec<Game>,
 }
 
 #[allow(non_snake_case)]
@@ -219,21 +217,43 @@ struct PGN {
     UTC_time: String,
     start_date: String,
     start_time: String,
-
 }
 
 impl From<Option<String>> for PGN {
-    fn from (pgn: Option<String>) -> Self {
-        
+    fn from(pgn: Option<String>) -> Self {
         let mut eco = String::new();
         let mut eco_url = String::new();
         let mut utc_date = String::new();
 
         if let Some(pgn_data) = pgn {
             for line in pgn_data.split('\n') {
-                if line.starts_with("[ECO \"") {eco = line.split(" ").nth(1).unwrap_or("").replace('"',"").replace(']',"").into();}
-                if line.starts_with("[ECOUrl \"") {eco_url = line.split(" ").nth(1).unwrap_or("").replace('"',"").replace(']',"").into();}
-                if line.starts_with("[UTCDate \"") {utc_date = line.split(" ").nth(1).unwrap_or("").replace('"',"").replace(']',"").into();}
+                if line.starts_with("[ECO \"") {
+                    eco = line
+                        .split(" ")
+                        .nth(1)
+                        .unwrap_or("")
+                        .replace('"', "")
+                        .replace(']', "")
+                        .into();
+                }
+                if line.starts_with("[ECOUrl \"") {
+                    eco_url = line
+                        .split(" ")
+                        .nth(1)
+                        .unwrap_or("")
+                        .replace('"', "")
+                        .replace(']', "")
+                        .into();
+                }
+                if line.starts_with("[UTCDate \"") {
+                    utc_date = line
+                        .split(" ")
+                        .nth(1)
+                        .unwrap_or("")
+                        .replace('"', "")
+                        .replace(']', "")
+                        .into();
+                }
             }
             Self {
                 ECO: eco,
@@ -243,9 +263,7 @@ impl From<Option<String>> for PGN {
                 start_time: "".to_string(),
                 start_date: "".to_string(),
             }
-        }
-
-        else {
+        } else {
             Self {
                 ECO: "".to_string(),
                 ECO_url: "".to_string(),
@@ -255,31 +273,26 @@ impl From<Option<String>> for PGN {
                 start_date: "".to_string(),
             }
         }
-        
     }
 }
 
-fn get_game_month_urls (user: &str) -> Vec <String> {
-
+fn get_game_month_urls(user: &str) -> Vec<String> {
     let url = format!("https://api.chess.com/pub/player/{}/games/archives", user);
-    
+
     let text = get(&url)
         .expect("Didn't get a response")
         .text()
         .expect("Invalid response");
-    
+
     let game_urls: GameUrls = serde_json::from_str(&text).expect("Serde error!");
 
     game_urls.archives
-
 }
 
-fn get_games (game_archive_urls: Vec<String>) -> Vec<Game> {
-
+fn get_games(game_archive_urls: Vec<String>) -> Vec<Game> {
     let mut games: Vec<Game> = vec![];
 
     for game_month in game_archive_urls {
-
         let games_text = get(&game_month)
             .expect("Didn't get a response")
             .text()
@@ -287,25 +300,23 @@ fn get_games (game_archive_urls: Vec<String>) -> Vec<Game> {
 
         let month_games: Games = serde_json::from_str(&games_text).expect("Serde error!");
         games.extend(month_games.games)
-
     }
 
     games
 }
 
 impl GameData {
-    pub fn download (users: Vec<&str>) -> Vec<GameData> {
+    pub fn download(users: Vec<&str>) -> Vec<GameData> {
         let mut game_data = vec![];
         for user in users {
             let urls = get_game_month_urls(&user);
             let games = get_games(urls);
-            let game_data_user: Vec<GameData> = games.into_iter()
-                               .map(|game| (game, user).into())
-                               .collect()
-                               ;
-            
-        game_data.extend(game_data_user);
+            let game_data_user: Vec<GameData> =
+                games.into_iter().map(|game| (game, user).into()).collect();
+
+            game_data.extend(game_data_user);
         }
-    game_data
+        game_data
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,19 +177,6 @@ impl From<&str> for PGN {
     }
 }
 
-fn get_game_month_urls(user: &str) -> Vec<String> {
-    let url = format!("https://api.chess.com/pub/player/{}/games/archives", user);
-
-    let text = get(&url)
-        .expect("Didn't get a response")
-        .text()
-        .expect("Invalid response");
-
-    serde_json::from_str::<GameUrls>(&text)
-        .expect("Serde error!")
-        .archives
-}
-
 #[derive(Debug, Serialize)]
 pub struct GameData {
     pub game_url: String,
@@ -282,6 +269,19 @@ impl From<(Game, &str)> for GameData {
     }
 }
 
+fn get_game_month_urls(user: &str) -> Vec<String> {
+    let url = format!("https://api.chess.com/pub/player/{}/games/archives", user);
+
+    let text = get(&url)
+        .expect("Didn't get a response")
+        .text()
+        .expect("Invalid response");
+
+    serde_json::from_str::<GameUrls>(&text)
+        .expect("Serde error!")
+        .archives
+}
+
 fn get_games(url: &str) -> Vec<Game> {
     let games_text = get(url)
         .expect("Didn't get a response")
@@ -291,4 +291,3 @@ fn get_games(url: &str) -> Vec<Game> {
         .expect("Serde error!")
         .games
 }
-


### PR DESCRIPTION
# Breaking Changes
This PR intends to clean up the library's main interface in such a way that is more idiomatic. Currently, the library takes in a `Vec` of usernames and outputs a `Vec<GameData>`. This implementation is certainly sufficient, but there are multiple issues with this:

1. The `Vec` container is not generic. Library users are forced to convert their collections to `Vec` types before using the library.
2. Having a `Vec` as the output may not be the most efficient and flexible interface due to mandatory memory allocations.
3. The internals of the library make heavy use of `Vec`. For the same reasons mentioned earlier, this is not as efficient as it can be.

With that said, this PR changes the API such that it only accepts a **single username** and outputs an **iterator** of `GameData` instead. The benefits of this change are twofold:

1. The responsibility of managing a _collection_ of users is passed on to the caller. We no longer have to require a `Vec` in the input.
2. Using an iterator as the output also allows greater flexibility over how the data is ultimately collected. One may opt to use a `Vec`, `HashSet`, etc. to `collect` all the `GameData` objects. Alternatively, as in the Readme and the examples, one may choose to take the first few games only. This allows the user to control how much data is queried. Regardless of the use case, since the output is an iterator, users may now iterate over the `GameData` objects in any way they please.

# Minor Changes
* Applied default formatting rules of [`rustfmt`](https://github.com/rust-lang/rustfmt).
* `.gitignore` has been added.
* The `Copy` and `Clone` traits have been `derive`-implemented for the various `enum`s in the library where applicable.

# Examples
Note that the greater flexibility mainly comes from the provided methods of the [`std::iter::Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) trait. We would still have the choice to `collect` into a `Vec`, but we now also have access to other iterator utilities.

## Printing All Games
```rust
use hikaru::GameData;
for game in GameData::download("hikaru") {
    dbg!(game);
}
```

## Collecting All Games in a `Vec`
```rust
use hikaru::GameData;
let games: Vec<_> = GameData::download("hikaru").collect();
```

## Retrieving the First Game
```rust
use hikaru::GameData;
dbg!(GameData::download("hikaru").next());
```

## Printing the First Ten Games
```rust
use hikaru::GameData;
for game in GameData::download("hikaru").take(10) {
    dbg!(game);
}
```